### PR TITLE
WEB-808: Format price text

### DIFF
--- a/components/BuyAssetForm/index.tsx
+++ b/components/BuyAssetForm/index.tsx
@@ -39,8 +39,8 @@ const BuyAssetForm = ({
       const balanceError =
         isBalanceEmpty || isBalanceInsufficient
           ? `Insufficient funds: this NFT is listed for ${formatPrice(
-              lowestAmountString
-            )} FOOBAR and your account balance is ${currentUserBalance}. Please deposit more funds to continue this transaction.`
+              lowestPrice
+            )} and your account balance is ${currentUserBalance}. Please deposit more funds to continue this transaction.`
           : '';
       setPurchasingError(balanceError);
     }

--- a/components/BuyAssetForm/index.tsx
+++ b/components/BuyAssetForm/index.tsx
@@ -6,6 +6,7 @@ import Button from '../Button';
 import { General, Amount, Row, Divider } from '../../styles/details.styled';
 import { ErrorMessage, DropdownMenu } from './BuyAssetForm.styled';
 import { useAuthContext, useModalContext, MODAL_TYPES } from '../Provider';
+import { formatPrice } from '../../utils';
 
 type Props = {
   templateId: string;
@@ -27,9 +28,8 @@ const BuyAssetForm = ({
   const [purchasingError, setPurchasingError] = useState<string>('');
   const [saleId, setSaleId] = useState('');
   const balanceAmount = parseFloat(currentUserBalance.split(' ')[0]);
-  const lowestAmount = lowestPrice
-    ? parseFloat(lowestPrice.split(' ')[0])
-    : undefined;
+  const lowestAmountString = lowestPrice.split(' ')[0];
+  const lowestAmount = lowestPrice ? parseFloat(lowestAmountString) : undefined;
   const isBalanceEmpty = balanceAmount === 0;
   const isBalanceInsufficient = lowestAmount && lowestAmount > balanceAmount;
 
@@ -38,8 +38,8 @@ const BuyAssetForm = ({
     if (currentUser && (lowestPrice || highestPrice)) {
       const balanceError =
         isBalanceEmpty || isBalanceInsufficient
-          ? `Insufficient funds: this NFT is listed for ${lowestAmount.toFixed(
-              6
+          ? `Insufficient funds: this NFT is listed for ${formatPrice(
+              lowestAmountString
             )} FOOBAR and your account balance is ${currentUserBalance}. Please deposit more funds to continue this transaction.`
           : '';
       setPurchasingError(balanceError);
@@ -100,9 +100,9 @@ const BuyAssetForm = ({
       </Row>
       <Divider />
       <General>Lowest Price</General>
-      <Amount>{lowestPrice ? lowestPrice : 'None'}</Amount>
+      <Amount>{lowestPrice ? formatPrice(lowestPrice) : 'None'}</Amount>
       <General>Highest Price</General>
-      <Amount>{highestPrice ? highestPrice : 'None'}</Amount>
+      <Amount>{highestPrice ? formatPrice(highestPrice) : 'None'}</Amount>
       <General>Serial number</General>
       <DropdownMenu
         name="Available Assets For Sale"

--- a/components/GridCard/index.tsx
+++ b/components/GridCard/index.tsx
@@ -41,8 +41,7 @@ const Card = ({
 
   const showPrice = () => {
     if (!priceText) return <EmptyPrice />;
-    const [amount, currency] = priceText.split(' ');
-    return <Price>{`${formatPrice(amount)} ${currency}`}</Price>;
+    return <Price>{formatPrice(priceText)}</Price>;
   };
 
   return (

--- a/components/GridCard/index.tsx
+++ b/components/GridCard/index.tsx
@@ -12,7 +12,7 @@ import {
   EmptyPrice,
   ShimmerBlock,
 } from './GridCard.styled';
-import { formatNumber } from '../../utils';
+import { formatNumber, formatPrice } from '../../utils';
 
 type Props = {
   text: string;
@@ -42,8 +42,7 @@ const Card = ({
   const showPrice = () => {
     if (!priceText) return <EmptyPrice />;
     const [amount, currency] = priceText.split(' ');
-    const shortenedAmount = parseFloat(amount).toFixed(2);
-    return <Price>{`${shortenedAmount} ${currency}`}</Price>;
+    return <Price>{`${formatPrice(amount)} ${currency}`}</Price>;
   };
 
   return (

--- a/components/NavBar/NavBar.styled.ts
+++ b/components/NavBar/NavBar.styled.ts
@@ -202,7 +202,7 @@ export const DesktopNavLink = styled.a<NavLinkProps>`
   cursor: pointer;
   margin-right: 40px;
   font-size: 16px;
-  line-height: 70px;
+  padding: 24px 0;
 `;
 
 export const MobileIcon = styled.div`

--- a/components/PriceInput/index.tsx
+++ b/components/PriceInput/index.tsx
@@ -58,9 +58,12 @@ const PriceInput = ({
       '.',
       'Enter',
       'Backspace',
+      'ArrowLeft',
+      'ArrowRight',
+      'Tab',
     ];
 
-    if (!validChars.includes(e.key)) {
+    if (!validChars.includes(e.key) && !e.metaKey) {
       e.preventDefault();
     }
 

--- a/pages/assets/[assetId].tsx
+++ b/pages/assets/[assetId].tsx
@@ -9,6 +9,7 @@ import AssetSaleDetails from '../../components/AssetSaleDetails';
 import AssetSaleForm from '../../components/AssetSaleForm';
 import { useAuthContext } from '../../components/Provider';
 import PageLayout from '../../components/PageLayout';
+import { formatPrice } from '../../utils';
 
 type Props = {
   asset: Asset;
@@ -67,7 +68,7 @@ const CollectionAssetDetail = ({ asset, sales, error }: Props): JSX.Element => {
         {isForSale ? (
           <AssetSaleDetails
             saleId={saleId}
-            salePrice={salePrice}
+            salePrice={formatPrice(salePrice)}
             isOwner={isOwner}
             template_id={template_id}
           />

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -1,3 +1,4 @@
-export const EMPTY_BALANCE = '0.000000 FOOBAR';
+export const EMPTY_BALANCE = '0 FOOBAR';
 export const TOKEN_SYMBOL = 'FOOBAR';
 export const TOKEN_PRECISION = 6;
+export const SHORTENED_TOKEN_PRECISION = 2;

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -45,18 +45,19 @@ export const addPrecisionDecimal = (
   if (number && number.includes('.')) return number;
   if (number && number.length > precision) {
     const insertDecimalAtIndex = number.length - precision;
-    return (
+    const numberString =
       number.slice(0, insertDecimalAtIndex) +
       '.' +
-      number.slice(insertDecimalAtIndex)
-    );
+      number.slice(insertDecimalAtIndex);
+    return parseFloat(numberString).toString();
   }
 
   let prependZeros = '';
   for (let i = 0; i < precision - number.length; i++) {
     prependZeros += '0';
   }
-  return `0.${prependZeros + number}`;
+  const numberString = `0.${prependZeros + number}`;
+  return parseFloat(numberString).toString();
 };
 
 export const formatPrice = (amount: string): string =>

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -60,7 +60,10 @@ export const addPrecisionDecimal = (
   return parseFloat(numberString).toString();
 };
 
-export const formatPrice = (amount: string): string =>
-  parseFloat(
-    parseFloat(amount).toFixed(SHORTENED_TOKEN_PRECISION)
+export const formatPrice = (priceString: string): string => {
+  const [price, currency] = priceString.split(' ');
+  const amount = parseFloat(
+    parseFloat(price).toFixed(SHORTENED_TOKEN_PRECISION)
   ).toLocaleString();
+  return `${amount} ${currency}`;
+};

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -1,7 +1,8 @@
-import { QueryParams } from '../utils/node-fetch';
 import dayjs from 'dayjs';
 import timezone from 'dayjs/plugin/timezone';
 import utc from 'dayjs/plugin/utc'; // dependent on utc plugin
+import { QueryParams } from './node-fetch';
+import { SHORTENED_TOKEN_PRECISION } from './constants';
 dayjs.extend(utc);
 dayjs.extend(timezone);
 
@@ -57,3 +58,8 @@ export const addPrecisionDecimal = (
   }
   return `0.${prependZeros + number}`;
 };
+
+export const formatPrice = (amount: string): string =>
+  parseFloat(
+    parseFloat(amount).toFixed(SHORTENED_TOKEN_PRECISION)
+  ).toLocaleString();


### PR DESCRIPTION
This PR resolves WEB-808 and #22.

- [x] Shorten all prices - round up to shortened token precision
- [x] Format prices with commas
- [x] Trim zeros in buy dropdown
- [x] Trim zeros sales history table)

<img width="1611" alt="Screen Shot 2021-03-22 at 11 55 59 AM" src="https://user-images.githubusercontent.com/32081352/112043236-b0120380-8b05-11eb-98a7-10f3abf4f006.png">
