### PR TITLE
WEB-821: Fix getAllTemplateSales state parameter

### DIFF
--- a/services/sales.ts
+++ b/services/sales.ts
@@ -111,7 +111,7 @@ export const getAllTemplateSales = async (
 
     while (hasResults) {
       const queryObject = {
-        state: '3',
+        state: '1',
         sort: 'price',
         order: 'asc',
         template_id: templateId,


### PR DESCRIPTION
Previously, the `state` parameter was using `state: 3` to pull in all previously sold assets, instead of using `state: 1` to pull in all unsold assets for sale.