### PR TITLE
WEB-812: Set up basic caching for sale history table avatars

### DIFF
--- a/components/SalesHistoryTable/index.tsx
+++ b/components/SalesHistoryTable/index.tsx
@@ -9,6 +9,7 @@ import { addPrecisionDecimal, parseTimestamp } from '../../utils';
 import { StyledTable } from './SalesHistoryTable.styled';
 import { useWindowSize } from '../../hooks';
 import { getFromApi } from '../../utils/browser-fetch';
+import { useAuthContext } from '../Provider';
 
 type Props = {
   tableData: Sale[];
@@ -59,6 +60,7 @@ const getAvatars = async (
 };
 
 const SalesHistoryTable = ({ tableData, error }: Props): JSX.Element => {
+  const { currentUser } = useAuthContext();
   const [avatars, setAvatars] = useState({});
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [tableHeaders, setTableHeaders] = useState<TableHeader[]>([]);
@@ -82,6 +84,15 @@ const SalesHistoryTable = ({ tableData, error }: Props): JSX.Element => {
       setIsLoading(false);
     })();
   }, [tableData]);
+
+  useEffect(() => {
+    if (currentUser) {
+      setAvatars({
+        ...avatars,
+        [currentUser.actor]: currentUser.avatar,
+      });
+    }
+  }, [currentUser]);
 
   const getTableContent = () => {
     return tableData.map((sale) => {

--- a/pages/api/profile.ts
+++ b/pages/api/profile.ts
@@ -1,0 +1,54 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import cache from '../../services/cache';
+import proton from '../../services/proton-rpc';
+
+interface MyAssetRequest extends NextApiRequest {
+  query: {
+    accounts: string[];
+  };
+}
+
+const handler = async (
+  req: MyAssetRequest,
+  res: NextApiResponse
+): Promise<void> => {
+  const {
+    method,
+    query: { accounts },
+  } = req;
+  switch (method) {
+    case 'POST':
+      break;
+    case 'PUT':
+      break;
+    case 'PATCH':
+      break;
+    default: {
+      try {
+        const chainAccounts =
+          typeof accounts === 'string' ? [accounts] : accounts;
+
+        for (const account of chainAccounts) {
+          if (!cache.has(account)) {
+            const res = await proton.getProfileImage({ account });
+
+            if (res) {
+              cache.set(account, res);
+            }
+          }
+        }
+
+        const avatarsByChainAccount = cache.getValues(chainAccounts);
+        res.status(200).send({ success: true, message: avatarsByChainAccount });
+      } catch (e) {
+        res.status(500).send({
+          success: false,
+          message: e.message || 'Error retrieving profile avatars',
+        });
+      }
+      break;
+    }
+  }
+};
+
+export default handler;

--- a/pages/api/profile.ts
+++ b/pages/api/profile.ts
@@ -26,7 +26,7 @@ const handler = async (
     default: {
       try {
         const chainAccounts =
-          typeof accounts === 'string' ? [accounts] : accounts;
+          typeof accounts === 'string' ? [accounts] : [...new Set(accounts)];
 
         for (const account of chainAccounts) {
           if (!cache.has(account)) {

--- a/services/cache.ts
+++ b/services/cache.ts
@@ -37,7 +37,9 @@ class Cache {
       return '';
     }
 
-    return this.cache.get(key).value;
+    const { value } = this.cache.get(key);
+    this.set(key, value);
+    return value;
   }
 
   delete(key: string) {
@@ -62,7 +64,6 @@ class Cache {
 
     for (const key of keys) {
       cacheValue[key] = this.getValue(key);
-      this.set(key, this.getValue(key));
     }
 
     return cacheValue;

--- a/services/cache.ts
+++ b/services/cache.ts
@@ -6,10 +6,12 @@ interface CacheValue {
 class Cache {
   cache: Map<string, CacheValue>;
   maxLength: number;
+  length: number;
 
   constructor() {
     this.cache = new Map();
-    this.maxLength = 100;
+    this.maxLength = 1000;
+    this.length = 0;
   }
 
   has(key: string) {
@@ -17,10 +19,12 @@ class Cache {
   }
 
   set(key: string, value: string) {
-    if (this.length() > this.maxLength) {
+    if (this.length >= this.maxLength) {
       const leastUsed = this.leastRecentlyUsed();
       this.delete(leastUsed);
     }
+
+    if (!this.has(key)) this.length += 1;
 
     return this.cache.set(key, {
       value,
@@ -37,15 +41,13 @@ class Cache {
   }
 
   delete(key: string) {
+    this.length -= 1;
     return this.cache.delete(key);
   }
 
   clear() {
+    this.length = 0;
     return this.cache.clear();
-  }
-
-  length() {
-    return Array.from(this.cache.keys()).length;
   }
 
   leastRecentlyUsed() {

--- a/services/cache.ts
+++ b/services/cache.ts
@@ -3,7 +3,7 @@ interface CacheValue {
   updatedAt: number;
 }
 
-class Cache {
+export class Cache {
   cache: Map<string, CacheValue>;
   maxLength: number;
   length: number;
@@ -14,49 +14,48 @@ class Cache {
     this.length = 0;
   }
 
-  has(key: string) {
+  has(key: string): boolean {
     return this.cache.has(key);
   }
 
-  set(key: string, value: string) {
+  set(key: string, value: string): number {
     if (this.length >= this.maxLength) {
-      const leastUsed = this.leastRecentlyUsed();
-      this.delete(leastUsed);
+      const leastUsedKey = this.leastRecentlyUsed();
+      this.delete(leastUsedKey);
     }
 
     if (!this.has(key)) this.length += 1;
-
-    return this.cache.set(key, {
+    this.cache.set(key, {
       value,
       updatedAt: Date.now(),
     });
+
+    return this.length;
   }
 
   getValue(key: string): string {
-    if (!this.has(key)) {
-      return '';
-    }
-
     const { value } = this.cache.get(key);
     this.set(key, value);
     return value;
   }
 
-  delete(key: string) {
+  delete(key: string): number {
     this.length -= 1;
-    return this.cache.delete(key);
+    this.cache.delete(key);
+    return this.length;
   }
 
-  clear() {
+  clear(): number {
     this.length = 0;
-    return this.cache.clear();
+    this.cache.clear();
+    return this.length;
   }
 
-  leastRecentlyUsed() {
-    const leastUsed = Array.from(this.cache.keys()).sort(
+  leastRecentlyUsed(): string {
+    const leastUsedKey = Array.from(this.cache.keys()).sort(
       (a, b) => this.cache.get(a).updatedAt - this.cache.get(b).updatedAt
     )[0];
-    return leastUsed;
+    return leastUsedKey;
   }
 
   getValues(keys: string[]): { [key: string]: string } {

--- a/services/cache.ts
+++ b/services/cache.ts
@@ -1,0 +1,70 @@
+interface CacheValue {
+  value: string;
+  updatedAt: number;
+}
+
+class Cache {
+  cache: Map<string, CacheValue>;
+  maxLength: number;
+
+  constructor() {
+    this.cache = new Map();
+    this.maxLength = 100;
+  }
+
+  has(key: string) {
+    return this.cache.has(key);
+  }
+
+  set(key: string, value: string) {
+    if (this.length() > this.maxLength) {
+      const leastUsed = this.leastRecentlyUsed();
+      this.delete(leastUsed);
+    }
+
+    return this.cache.set(key, {
+      value,
+      updatedAt: Date.now(),
+    });
+  }
+
+  getValue(key: string): string {
+    if (!this.has(key)) {
+      return '';
+    }
+
+    return this.cache.get(key).value;
+  }
+
+  delete(key: string) {
+    return this.cache.delete(key);
+  }
+
+  clear() {
+    return this.cache.clear();
+  }
+
+  length() {
+    return Array.from(this.cache.keys()).length;
+  }
+
+  leastRecentlyUsed() {
+    const leastUsed = Array.from(this.cache.keys()).sort(
+      (a, b) => this.cache.get(a).updatedAt - this.cache.get(b).updatedAt
+    )[0];
+    return leastUsed;
+  }
+
+  getValues(keys: string[]): { [key: string]: string } {
+    const cacheValue = {};
+
+    for (const key of keys) {
+      cacheValue[key] = this.getValue(key);
+      this.set(key, this.getValue(key));
+    }
+
+    return cacheValue;
+  }
+}
+
+export default new Cache();

--- a/services/proton-rpc.ts
+++ b/services/proton-rpc.ts
@@ -54,8 +54,8 @@ class ProtonJs {
       lower_bound: account,
       upper_bound: account,
     });
-    const { avatar } = rows[0];
-    return avatar;
+
+    return !rows.length ? '' : rows[0].avatar;
   };
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve"
+    "jsx": "preserve",
+    "downlevelIteration": true
   },
   "include": [
     "next-env.d.ts",

--- a/utils/withCache.ts
+++ b/utils/withCache.ts
@@ -1,0 +1,36 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import proton from '../services/proton-rpc';
+import cache, { Cache } from '../services/cache';
+
+export interface MyAssetRequest extends NextApiRequest {
+  query: {
+    accounts: string[];
+  };
+  cache: Cache;
+}
+
+type Handler = (req: MyAssetRequest, res: NextApiResponse) => Promise<void>;
+
+export const conditionallyUpdateCache = (
+  account: string,
+  cache: Cache
+): Promise<string> =>
+  new Promise((resolve) => {
+    if (!cache.has(account)) {
+      proton.getProfileImage({ account }).then((avatar) => {
+        cache.set(account, avatar);
+        resolve(avatar);
+      });
+    } else {
+      resolve(account);
+    }
+  });
+
+const withCache = (handler: Handler): Handler => {
+  return async (req, res) => {
+    req.cache = cache;
+    return handler(req, res);
+  };
+};
+
+export default withCache;


### PR DESCRIPTION
**Note: cache works in built version of the app, but not in dev.**

Testing steps:
1. Add `console.log(this.length)` in the `Cache.set` method:
<img width="352" alt="Screen Shot 2021-03-23 at 6 26 49 PM" src="https://user-images.githubusercontent.com/32081352/112240329-5a248500-8c05-11eb-812b-e22ec3264637.png">

2. `yarn build`
3. `yarn start`
4. Navigate to http://localhost:3000/10 and notice how the backend cache length increments in the logs
5. Navigate to Marketplace and select another template detail page to visit - notice that the cache length continues to increment even when navigating to different pages. (Run the application in dev mode, and compare - notice that the cache length resets upon navigating to different pages.)