### PR TITLE
WEB-841: Create sale creation and sale cancellation modals

### DIFF
--- a/components/AssetSaleDetails/index.tsx
+++ b/components/AssetSaleDetails/index.tsx
@@ -1,7 +1,6 @@
 import React, { Dispatch, SetStateAction } from 'react';
 import { useRouter } from 'next/router';
-import { useAuthContext } from '../Provider';
-import ProtonSDK from '../../services/proton';
+import { useModalContext, MODAL_TYPES } from '../Provider';
 import Button from '../Button';
 import { General, Amount } from '../../styles/details.styled';
 import { EMPTY_BALANCE } from '../../utils/constants';
@@ -22,18 +21,7 @@ const AssetSaleDetails = ({
   setShouldReload,
 }: Props): JSX.Element => {
   const router = useRouter();
-  const { currentUser } = useAuthContext();
-
-  const cancelSale = async () => {
-    const res = await ProtonSDK.cancelSale({
-      actor: currentUser ? currentUser.actor : '',
-      sale_id: saleId,
-    });
-
-    if (res.success) {
-      setShouldReload(true);
-    }
-  };
+  const { openModal, setModalProps } = useModalContext();
 
   return (
     <section>
@@ -43,9 +31,34 @@ const AssetSaleDetails = ({
         View Listing
       </Button>
       {isOwner ? (
-        <Button fullWidth filled rounded onClick={cancelSale}>
-          Cancel Sale
-        </Button>
+        <>
+          <Button
+            fullWidth
+            filled
+            rounded
+            onClick={() => {
+              openModal(MODAL_TYPES.CANCEL_SALE);
+              setModalProps({
+                saleId,
+                setShouldReload,
+              });
+            }}>
+            Cancel Sale
+          </Button>
+          <Button
+            fullWidth
+            filled
+            rounded
+            onClick={() => {
+              openModal(MODAL_TYPES.CANCEL_ALL_SALES);
+              setModalProps({
+                saleIds: [saleId],
+                setShouldReload,
+              });
+            }}>
+            (TEST) Cancel All Sales
+          </Button>
+        </>
       ) : (
         ''
       )}

--- a/components/AssetSaleDetails/index.tsx
+++ b/components/AssetSaleDetails/index.tsx
@@ -50,7 +50,7 @@ const AssetSaleDetails = ({
             filled
             rounded
             onClick={() => {
-              openModal(MODAL_TYPES.CANCEL_ALL_SALES);
+              openModal(MODAL_TYPES.CANCEL_MULTIPLE_SALES);
               setModalProps({
                 saleIds: [saleId],
                 setShouldReload,

--- a/components/AssetSaleForm/index.tsx
+++ b/components/AssetSaleForm/index.tsx
@@ -1,10 +1,8 @@
-import React, { useState, Dispatch, SetStateAction } from 'react';
-import ProtonSDK from '../../services/proton';
+import React, { Dispatch, SetStateAction } from 'react';
 import Button from '../Button';
-import PriceInput from '../PriceInput';
-import { useAuthContext } from '../Provider';
+import { useModalContext, MODAL_TYPES } from '../Provider';
 import { General } from '../../styles/details.styled';
-import { TOKEN_SYMBOL, TOKEN_PRECISION } from '../../utils/constants';
+import { TOKEN_SYMBOL } from '../../utils/constants';
 
 type Props = {
   asset_id: string;
@@ -12,34 +10,35 @@ type Props = {
 };
 
 const AssetSaleForm = ({ asset_id, setShouldReload }: Props): JSX.Element => {
-  const { currentUser } = useAuthContext();
-  const [amount, setAmount] = useState<string>('');
-
-  const createSale = async () => {
-    const formattedAmount = parseFloat(amount).toFixed(TOKEN_PRECISION);
-    const res = await ProtonSDK.createSale({
-      seller: currentUser ? currentUser.actor : '',
-      asset_id,
-      price: `${formattedAmount} ${TOKEN_SYMBOL}`,
-      currency: `${TOKEN_PRECISION},${TOKEN_SYMBOL}`,
-    });
-
-    if (res.success) {
-      setShouldReload(true);
-    }
-  };
-
+  const { openModal, setModalProps } = useModalContext();
   return (
     <section>
       <General>Sales Price ({TOKEN_SYMBOL})</General>
-      <PriceInput
-        amount={amount}
-        setAmount={setAmount}
-        submit={() => createSale()}
-        placeholder="Enter Price"
-      />
-      <Button filled rounded fullWidth onClick={createSale}>
+      <Button
+        filled
+        rounded
+        fullWidth
+        onClick={() => {
+          openModal(MODAL_TYPES.CREATE_SALE);
+          setModalProps({
+            assetId: asset_id,
+            setShouldReload,
+          });
+        }}>
         Mark for sale
+      </Button>
+      <Button
+        filled
+        rounded
+        fullWidth
+        onClick={() => {
+          openModal(MODAL_TYPES.CREATE_MULTIPLE_SALES);
+          setModalProps({
+            assetIds: [asset_id],
+            setShouldReload,
+          });
+        }}>
+        (TEST) Mark all for sale
       </Button>
     </section>
   );

--- a/components/Button/Button.styled.ts
+++ b/components/Button/Button.styled.ts
@@ -1,20 +1,18 @@
 import styled from 'styled-components';
 
-type ButtonProps = {
-  color: string;
-  hoverColor: string;
+export interface ButtonProps {
   filled?: boolean;
   rounded?: boolean;
   fullWidth?: boolean;
-};
+}
 
 export const StyledButton = styled.button<ButtonProps>`
   padding: 8px 16px;
   margin: 12px 0;
   border-radius: ${({ rounded }) => (rounded ? '20px' : '4px')};
   border: ${({ filled }) => (filled ? 'none' : ' 1px solid #e8ecfd')};
-  background-color: ${({ filled, color }) => (filled ? color : '#ffffff')};
-  color: ${({ filled, color }) => (filled ? '#ffffff' : color)};
+  background-color: ${({ filled }) => (filled ? '#8a9ef5' : '#ffffff')};
+  color: ${({ filled }) => (filled ? '#ffffff' : '#8a9ef5')};
   cursor: pointer;
   outline: none;
   transition: 0.2s;
@@ -28,8 +26,7 @@ export const StyledButton = styled.button<ButtonProps>`
   :focus {
     opacity: 1;
     color: #ffffff;
-    background-color: ${({ filled, hoverColor }) =>
-      filled ? hoverColor : '#8a9ef5'};
+    background-color: ${({ filled }) => (filled ? '#4d5dc1' : '#8a9ef5')};
     box-shadow: 0 8px 12px -4px rgba(130, 136, 148, 0.24),
       0 0 4px 0 rgba(141, 141, 148, 0.16), 0 0 2px 0 rgba(141, 141, 148, 0.12);
   }

--- a/components/Button/Button.styled.ts
+++ b/components/Button/Button.styled.ts
@@ -1,6 +1,8 @@
 import styled from 'styled-components';
 
 type ButtonProps = {
+  color: string;
+  hoverColor: string;
   filled?: boolean;
   rounded?: boolean;
   fullWidth?: boolean;
@@ -11,8 +13,8 @@ export const StyledButton = styled.button<ButtonProps>`
   margin: 12px 0;
   border-radius: ${({ rounded }) => (rounded ? '20px' : '4px')};
   border: ${({ filled }) => (filled ? 'none' : ' 1px solid #e8ecfd')};
-  background-color: ${({ filled }) => (filled ? '#8a9ef5' : '#ffffff')};
-  color: ${({ filled }) => (filled ? '#ffffff' : '#8a9ef5')};
+  background-color: ${({ filled, color }) => (filled ? color : '#ffffff')};
+  color: ${({ filled, color }) => (filled ? '#ffffff' : color)};
   cursor: pointer;
   outline: none;
   transition: 0.2s;
@@ -26,7 +28,8 @@ export const StyledButton = styled.button<ButtonProps>`
   :focus {
     opacity: 1;
     color: #ffffff;
-    background-color: ${({ filled }) => (filled ? '#4d5dc1' : '#8a9ef5')};
+    background-color: ${({ filled, hoverColor }) =>
+      filled ? hoverColor : '#8a9ef5'};
     box-shadow: 0 8px 12px -4px rgba(130, 136, 148, 0.24),
       0 0 4px 0 rgba(141, 141, 148, 0.16), 0 0 2px 0 rgba(141, 141, 148, 0.12);
   }

--- a/components/Button/index.tsx
+++ b/components/Button/index.tsx
@@ -7,6 +7,8 @@ type Props = {
   rounded?: boolean;
   fullWidth?: boolean;
   disabled?: boolean;
+  color?: string;
+  hoverColor?: string;
 };
 
 const Button = ({
@@ -16,15 +18,24 @@ const Button = ({
   rounded,
   fullWidth,
   disabled,
+  color,
+  hoverColor,
 }: Props): JSX.Element => (
   <StyledButton
     filled={filled}
     rounded={rounded}
     fullWidth={fullWidth}
     disabled={disabled}
+    color={color}
+    hoverColor={hoverColor}
     onClick={onClick}>
     {children}
   </StyledButton>
 );
+
+Button.defaultProps = {
+  color: '#8a9ef5',
+  hoverColor: '#4d5dc1',
+};
 
 export default Button;

--- a/components/Button/index.tsx
+++ b/components/Button/index.tsx
@@ -7,8 +7,6 @@ type Props = {
   rounded?: boolean;
   fullWidth?: boolean;
   disabled?: boolean;
-  color?: string;
-  hoverColor?: string;
 };
 
 const Button = ({
@@ -18,24 +16,15 @@ const Button = ({
   rounded,
   fullWidth,
   disabled,
-  color,
-  hoverColor,
 }: Props): JSX.Element => (
   <StyledButton
     filled={filled}
     rounded={rounded}
     fullWidth={fullWidth}
     disabled={disabled}
-    color={color}
-    hoverColor={hoverColor}
     onClick={onClick}>
     {children}
   </StyledButton>
 );
-
-Button.defaultProps = {
-  color: '#8a9ef5',
-  hoverColor: '#4d5dc1',
-};
 
 export default Button;

--- a/components/Modal/CancelSaleModal.tsx
+++ b/components/Modal/CancelSaleModal.tsx
@@ -3,7 +3,7 @@ import {
   useAuthContext,
   useModalContext,
   CancelSaleModalProps,
-  CancelAllSalesModalProps,
+  CancelMultipleSalesModalProps,
 } from '../Provider';
 import {
   Background,
@@ -94,10 +94,13 @@ export const CancelSaleModal = (): JSX.Element => {
   );
 };
 
-export const CancelAllSalesModal = (): JSX.Element => {
+export const CancelMultipleSalesModal = (): JSX.Element => {
   const { currentUser } = useAuthContext();
   const { closeModal, modalProps } = useModalContext();
-  const { saleIds, setShouldReload } = modalProps as CancelAllSalesModalProps;
+  const {
+    saleIds,
+    setShouldReload,
+  } = modalProps as CancelMultipleSalesModalProps;
 
   const onButtonClick = async () => {
     try {

--- a/components/Modal/CancelSaleModal.tsx
+++ b/components/Modal/CancelSaleModal.tsx
@@ -1,0 +1,121 @@
+import { MouseEvent } from 'react';
+import {
+  useAuthContext,
+  useModalContext,
+  CancelSaleModalProps,
+  CancelAllSalesModalProps,
+} from '../Provider';
+import Button from '../Button';
+import {
+  Background,
+  ModalBox,
+  Section,
+  CloseIconContainer,
+  Title,
+  Description,
+} from './Modal.styled';
+import { ReactComponent as CloseIcon } from '../../public/close.svg';
+import ProtonSDK from '../../services/proton';
+
+type Props = {
+  title: string;
+  description: string;
+  buttonText: string;
+  onButtonClick: () => Promise<void>;
+};
+
+const CancelModal = ({
+  title,
+  description,
+  buttonText,
+  onButtonClick,
+}: Props): JSX.Element => {
+  const { closeModal } = useModalContext();
+
+  const handleBackgroundClick = (e: MouseEvent) => {
+    if (e.target === e.currentTarget) {
+      closeModal();
+    }
+  };
+
+  return (
+    <Background onClick={handleBackgroundClick}>
+      <ModalBox>
+        <Section>
+          <Title>{title}</Title>
+          <CloseIconContainer role="button" onClick={closeModal}>
+            <CloseIcon />
+          </CloseIconContainer>
+        </Section>
+        <Description>{description}</Description>
+        <Button
+          fullWidth
+          filled
+          rounded
+          color="#fb849a"
+          hoverColor="#ff778e"
+          onClick={onButtonClick}>
+          {buttonText}
+        </Button>
+      </ModalBox>
+    </Background>
+  );
+};
+
+export const CancelSaleModal = (): JSX.Element => {
+  const { currentUser } = useAuthContext();
+  const { closeModal, modalProps } = useModalContext();
+  const { saleId, setShouldReload } = modalProps as CancelSaleModalProps;
+
+  const cancelSale = async () => {
+    const res = await ProtonSDK.cancelSale({
+      actor: currentUser ? currentUser.actor : '',
+      sale_id: saleId,
+    });
+
+    if (res.success) {
+      closeModal();
+      setShouldReload(true);
+    }
+  };
+
+  return (
+    <CancelModal
+      title="Cancel Sale?"
+      description="By canceling sale your NFT will be removed from the marketplace until
+          you market for sale again."
+      buttonText="Cancel Sale"
+      onButtonClick={cancelSale}
+    />
+  );
+};
+
+export const CancelAllSalesModal = (): JSX.Element => {
+  const { currentUser } = useAuthContext();
+  const { closeModal, modalProps } = useModalContext();
+  const { saleIds, setShouldReload } = modalProps as CancelAllSalesModalProps;
+
+  const onButtonClick = async () => {
+    try {
+      console.log(
+        `${currentUser.actor} is canceling the following sales: ${saleIds.join(
+          ', '
+        )}`
+      );
+      closeModal();
+      setShouldReload(true);
+    } catch (err) {
+      throw new Error(err.message);
+    }
+  };
+
+  return (
+    <CancelModal
+      title="Cancel Sales?"
+      description={`You are canceling ${saleIds.length} items for sale. By canceling sales your NFTs will be removed from the marketplace until
+          you market them for sale again.`}
+      buttonText="Cancel All Sales"
+      onButtonClick={onButtonClick}
+    />
+  );
+};

--- a/components/Modal/CancelSaleModal.tsx
+++ b/components/Modal/CancelSaleModal.tsx
@@ -104,13 +104,15 @@ export const CancelMultipleSalesModal = (): JSX.Element => {
 
   const onButtonClick = async () => {
     try {
-      console.log(
-        `${currentUser.actor} is canceling the following sales: ${saleIds.join(
-          ', '
-        )}`
-      );
-      closeModal();
-      setShouldReload(true);
+      const res = await ProtonSDK.cancelMultipleSales({
+        actor: currentUser ? currentUser.actor : '',
+        saleIds,
+      });
+
+      if (res.success) {
+        closeModal();
+        setShouldReload(true);
+      }
     } catch (err) {
       throw new Error(err.message);
     }

--- a/components/Modal/CancelSaleModal.tsx
+++ b/components/Modal/CancelSaleModal.tsx
@@ -5,7 +5,6 @@ import {
   CancelSaleModalProps,
   CancelAllSalesModalProps,
 } from '../Provider';
-import Button from '../Button';
 import {
   Background,
   ModalBox,
@@ -13,6 +12,9 @@ import {
   CloseIconContainer,
   Title,
   Description,
+  Row,
+  Spacer,
+  HalfButton,
 } from './Modal.styled';
 import { ReactComponent as CloseIcon } from '../../public/close.svg';
 import ProtonSDK from '../../services/proton';
@@ -48,15 +50,17 @@ const CancelModal = ({
           </CloseIconContainer>
         </Section>
         <Description>{description}</Description>
-        <Button
-          fullWidth
-          filled
-          rounded
-          color="#fb849a"
-          hoverColor="#ff778e"
-          onClick={onButtonClick}>
-          {buttonText}
-        </Button>
+        <Row>
+          <Spacer />
+          <HalfButton
+            filled
+            rounded
+            color="#fb849a"
+            hoverColor="#ff778e"
+            onClick={onButtonClick}>
+            {buttonText}
+          </HalfButton>
+        </Row>
       </ModalBox>
     </Background>
   );

--- a/components/Modal/CancelSaleModal.tsx
+++ b/components/Modal/CancelSaleModal.tsx
@@ -86,8 +86,8 @@ export const CancelSaleModal = (): JSX.Element => {
   return (
     <CancelModal
       title="Cancel Sale?"
-      description="By canceling sale your NFT will be removed from the marketplace until
-          you market for sale again."
+      description="By canceling the sale, your NFT will be removed from the marketplace until
+          you mark it for sale again."
       buttonText="Cancel Sale"
       onButtonClick={cancelSale}
     />
@@ -121,8 +121,8 @@ export const CancelMultipleSalesModal = (): JSX.Element => {
   return (
     <CancelModal
       title="Cancel Sales?"
-      description={`You are canceling ${saleIds.length} items for sale. By canceling sales your NFTs will be removed from the marketplace until
-          you market them for sale again.`}
+      description={`You are canceling ${saleIds.length} items for sale. By canceling the sales, your NFTs will be removed from the marketplace until
+          you mark them for sale again.`}
       buttonText="Cancel All Sales"
       onButtonClick={onButtonClick}
     />

--- a/components/Modal/CreateSaleModal.tsx
+++ b/components/Modal/CreateSaleModal.tsx
@@ -121,13 +121,18 @@ export const CreateMultipleSalesModal = (): JSX.Element => {
 
   const createMultipleSales = async () => {
     try {
-      console.log(
-        `${currentUser.actor} is selling the following assets: ${assetIds.join(
-          ', '
-        )}`
-      );
-      closeModal();
-      setShouldReload(true);
+      const formattedAmount = parseFloat(amount).toFixed(TOKEN_PRECISION);
+      const res = await ProtonSDK.createMultipleSales({
+        seller: currentUser ? currentUser.actor : '',
+        assetIds,
+        price: `${formattedAmount} ${TOKEN_SYMBOL}`,
+        currency: `${TOKEN_PRECISION},${TOKEN_SYMBOL}`,
+      });
+
+      if (res.success) {
+        closeModal();
+        setShouldReload(true);
+      }
     } catch (err) {
       throw new Error(err.message);
     }

--- a/components/Modal/CreateSaleModal.tsx
+++ b/components/Modal/CreateSaleModal.tsx
@@ -5,7 +5,6 @@ import {
   CreateSaleModalProps,
   CreateMultipleSalesModalProps,
 } from '../Provider';
-import Button from '../Button';
 import PriceInput from '../PriceInput';
 import {
   Background,
@@ -15,6 +14,9 @@ import {
   Title,
   Description,
   InputLabel,
+  Row,
+  Spacer,
+  HalfButton,
 } from './Modal.styled';
 import { ReactComponent as CloseIcon } from '../../public/close.svg';
 import { TOKEN_SYMBOL, TOKEN_PRECISION } from '../../utils/constants';
@@ -64,9 +66,12 @@ const SaleModal = ({
             placeholder={`Enter amount (${TOKEN_SYMBOL})`}
           />
         </InputLabel>
-        <Button fullWidth filled rounded onClick={onButtonClick}>
-          {buttonText}
-        </Button>
+        <Row>
+          <Spacer />
+          <HalfButton filled rounded onClick={onButtonClick}>
+            {buttonText}
+          </HalfButton>
+        </Row>
       </ModalBox>
     </Background>
   );

--- a/components/Modal/CreateSaleModal.tsx
+++ b/components/Modal/CreateSaleModal.tsx
@@ -1,0 +1,141 @@
+import { useState, MouseEvent, Dispatch, SetStateAction } from 'react';
+import {
+  useAuthContext,
+  useModalContext,
+  CreateSaleModalProps,
+  CreateMultipleSalesModalProps,
+} from '../Provider';
+import Button from '../Button';
+import PriceInput from '../PriceInput';
+import {
+  Background,
+  ModalBox,
+  Section,
+  CloseIconContainer,
+  Title,
+  Description,
+  InputLabel,
+} from './Modal.styled';
+import { ReactComponent as CloseIcon } from '../../public/close.svg';
+import { TOKEN_SYMBOL, TOKEN_PRECISION } from '../../utils/constants';
+import ProtonSDK from '../../services/proton';
+
+type Props = {
+  title: string;
+  description: string;
+  buttonText: string;
+  amount: string;
+  onButtonClick: () => Promise<void>;
+  setAmount: Dispatch<SetStateAction<string>>;
+};
+
+const SaleModal = ({
+  title,
+  description,
+  buttonText,
+  amount,
+  setAmount,
+  onButtonClick,
+}: Props): JSX.Element => {
+  const { closeModal } = useModalContext();
+
+  const handleBackgroundClick = (e: MouseEvent) => {
+    if (e.target === e.currentTarget) {
+      closeModal();
+    }
+  };
+
+  return (
+    <Background onClick={handleBackgroundClick}>
+      <ModalBox>
+        <Section>
+          <Title>{title}</Title>
+          <CloseIconContainer role="button" onClick={closeModal}>
+            <CloseIcon />
+          </CloseIconContainer>
+        </Section>
+        <Description>{description}</Description>
+        <InputLabel>
+          NFT Price
+          <PriceInput
+            amount={amount}
+            setAmount={setAmount}
+            submit={null}
+            placeholder={`Enter amount (${TOKEN_SYMBOL})`}
+          />
+        </InputLabel>
+        <Button fullWidth filled rounded onClick={onButtonClick}>
+          {buttonText}
+        </Button>
+      </ModalBox>
+    </Background>
+  );
+};
+
+export const CreateSaleModal = (): JSX.Element => {
+  const { currentUser } = useAuthContext();
+  const { closeModal, modalProps } = useModalContext();
+  const { assetId, setShouldReload } = modalProps as CreateSaleModalProps;
+  const [amount, setAmount] = useState<string>('');
+
+  const createOneSale = async () => {
+    const formattedAmount = parseFloat(amount).toFixed(TOKEN_PRECISION);
+    const res = await ProtonSDK.createSale({
+      seller: currentUser ? currentUser.actor : '',
+      asset_id: assetId,
+      price: `${formattedAmount} ${TOKEN_SYMBOL}`,
+      currency: `${TOKEN_PRECISION},${TOKEN_SYMBOL}`,
+    });
+
+    if (res.success) {
+      closeModal();
+      setShouldReload(true);
+    }
+  };
+
+  return (
+    <SaleModal
+      title="Listing Price"
+      description="Enter the amount you want to sell your NFT for."
+      buttonText="Mark for sale"
+      amount={amount}
+      setAmount={setAmount}
+      onButtonClick={createOneSale}
+    />
+  );
+};
+
+export const CreateMultipleSalesModal = (): JSX.Element => {
+  const { currentUser } = useAuthContext();
+  const { closeModal, modalProps } = useModalContext();
+  const {
+    assetIds,
+    setShouldReload,
+  } = modalProps as CreateMultipleSalesModalProps;
+  const [amount, setAmount] = useState<string>('');
+
+  const createMultipleSales = async () => {
+    try {
+      console.log(
+        `${currentUser.actor} is selling the following assets: ${assetIds.join(
+          ', '
+        )}`
+      );
+      closeModal();
+      setShouldReload(true);
+    } catch (err) {
+      throw new Error(err.message);
+    }
+  };
+
+  return (
+    <SaleModal
+      title="Listing Price"
+      description={`You are putting up ${assetIds.length} items for sale. Enter the amount you want to sell each of your NFTs for.`}
+      buttonText="Mark all for sale"
+      amount={amount}
+      setAmount={setAmount}
+      onButtonClick={createMultipleSales}
+    />
+  );
+};

--- a/components/Modal/Modal.styled.ts
+++ b/components/Modal/Modal.styled.ts
@@ -1,7 +1,16 @@
 import styled from 'styled-components';
 import { MaxWidth } from '../../styles/MaxWidth.styled';
 import { breakpoint } from '../../styles/Breakpoints';
+<<<<<<< HEAD
 import { StyledButton } from '../Button/Button.styled';
+=======
+import { StyledButton, ButtonProps } from '../Button/Button.styled';
+
+interface HalfButtonProps extends ButtonProps {
+  color?: string;
+  hoverColor?: string;
+}
+>>>>>>> 88d2e04... Update sale creation and cancellation modal buttons
 
 export const Background = styled.div`
   z-index: 3;
@@ -97,8 +106,22 @@ export const Row = styled.div`
   display: flex;
 `;
 
-export const HalfButton = styled(StyledButton)`
+export const HalfButton = styled(StyledButton)<HalfButtonProps>`
   flex: 1;
+
+  ${({ color }) =>
+    color &&
+    `
+    background-color: ${color};
+  `}
+
+  ${({ hoverColor }) =>
+    hoverColor &&
+    `
+    :hover {
+      background-color: ${hoverColor};
+    }
+  `}
 `;
 
 export const Spacer = styled.div`

--- a/components/Modal/Modal.styled.ts
+++ b/components/Modal/Modal.styled.ts
@@ -1,16 +1,12 @@
 import styled from 'styled-components';
 import { MaxWidth } from '../../styles/MaxWidth.styled';
 import { breakpoint } from '../../styles/Breakpoints';
-<<<<<<< HEAD
-import { StyledButton } from '../Button/Button.styled';
-=======
 import { StyledButton, ButtonProps } from '../Button/Button.styled';
 
 interface HalfButtonProps extends ButtonProps {
   color?: string;
   hoverColor?: string;
 }
->>>>>>> 88d2e04... Update sale creation and cancellation modal buttons
 
 export const Background = styled.div`
   z-index: 3;

--- a/components/Modal/Modal.styled.ts
+++ b/components/Modal/Modal.styled.ts
@@ -65,6 +65,7 @@ export const Description = styled.p`
 
 export const InputLabel = styled(Description).attrs({ as: 'label' })`
   font-size: 12px;
+  line-height: 24px;
   display: flex;
   flex-direction: column;
   margin: 0;
@@ -90,51 +91,6 @@ export const ErrorMessage = styled(Description).attrs({ as: 'span' })`
   font-size: 12px;
   color: red;
   margin-bottom: 0;
-`;
-
-export const Input = styled.input`
-  font-family: GilroyMedium;
-  font-size: 14px;
-  line-height: 24px;
-  color: #7578b5;
-  border-radius: 4px;
-  padding: 8px;
-  border: solid 1px #e8ecfd;
-  margin-bottom: 12px;
-
-  ::-webkit-inner-spin-button,
-  ::-webkit-outer-spin-button {
-    -webkit-appearance: none;
-    -moz-appearance: none;
-    appearance: none;
-    margin: 0;
-  }
-
-  ::placeholder {
-    color: #7578b5;
-  }
-`;
-
-export const StyledLink = styled.a`
-  font-family: GilroySemiBold;
-  font-size: 14px;
-  line-height: 24px;
-  color: #8a9ef5;
-  width: 100%;
-  text-decoration: underline;
-  cursor: pointer;
-  transition: 0.2s;
-  text-align: left;
-
-  :hover {
-    color: #4d5dc1;
-  }
-`;
-
-export const LinkButton = styled(StyledLink).attrs({ as: 'button' })`
-  padding: 0;
-  border: none;
-  background: none;
 `;
 
 export const Row = styled.div`

--- a/components/Modal/index.tsx
+++ b/components/Modal/index.tsx
@@ -1,3 +1,8 @@
+<<<<<<< HEAD
 export { ClaimBalanceModal } from './ClaimBalanceModal';
 export { CancelSaleModal, CancelAllSalesModal } from './CancelSaleModal';
+=======
+export { WithdrawModal } from './WithdrawModal';
+export { CancelSaleModal, CancelMultipleSalesModal } from './CancelSaleModal';
+>>>>>>> a4edb15... Rename cancelAllSaleModal to cancelMultipleSalesModal
 export { CreateSaleModal, CreateMultipleSalesModal } from './CreateSaleModal';

--- a/components/Modal/index.tsx
+++ b/components/Modal/index.tsx
@@ -1,1 +1,3 @@
 export { ClaimBalanceModal } from './ClaimBalanceModal';
+export { CancelSaleModal, CancelAllSalesModal } from './CancelSaleModal';
+export { CreateSaleModal, CreateMultipleSalesModal } from './CreateSaleModal';

--- a/components/Modal/index.tsx
+++ b/components/Modal/index.tsx
@@ -1,8 +1,3 @@
-<<<<<<< HEAD
 export { ClaimBalanceModal } from './ClaimBalanceModal';
-export { CancelSaleModal, CancelAllSalesModal } from './CancelSaleModal';
-=======
-export { WithdrawModal } from './WithdrawModal';
 export { CancelSaleModal, CancelMultipleSalesModal } from './CancelSaleModal';
->>>>>>> a4edb15... Rename cancelAllSaleModal to cancelMultipleSalesModal
 export { CreateSaleModal, CreateMultipleSalesModal } from './CreateSaleModal';

--- a/components/PageLayout/index.tsx
+++ b/components/PageLayout/index.tsx
@@ -8,7 +8,7 @@ import {
   CreateSaleModal,
   CreateMultipleSalesModal,
   CancelSaleModal,
-  CancelAllSalesModal,
+  CancelMultipleSalesModal,
 } from '../Modal';
 
 type Props = {
@@ -33,8 +33,8 @@ const PageLayout = ({ title, children }: Props): JSX.Element => {
         return <CreateMultipleSalesModal />;
       case MODAL_TYPES.CANCEL_SALE:
         return <CancelSaleModal />;
-      case MODAL_TYPES.CANCEL_ALL_SALES:
-        return <CancelAllSalesModal />;
+      case MODAL_TYPES.CANCEL_MULTIPLE_SALES:
+        return <CancelMultipleSalesModal />;
       default:
         return null;
     }

--- a/components/PageLayout/index.tsx
+++ b/components/PageLayout/index.tsx
@@ -3,7 +3,13 @@ import Head from 'next/head';
 import Router from 'next/router';
 import { Main, Container } from './PageLayout.styled';
 import { useModalContext, MODAL_TYPES } from '../Provider';
-import { ClaimBalanceModal } from '../Modal';
+import {
+  ClaimBalanceModal,
+  CreateSaleModal,
+  CreateMultipleSalesModal,
+  CancelSaleModal,
+  CancelAllSalesModal,
+} from '../Modal';
 
 type Props = {
   title: string;
@@ -21,6 +27,14 @@ const PageLayout = ({ title, children }: Props): JSX.Element => {
     switch (modalType) {
       case MODAL_TYPES.CLAIM:
         return <ClaimBalanceModal />;
+      case MODAL_TYPES.CREATE_SALE:
+        return <CreateSaleModal />;
+      case MODAL_TYPES.CREATE_MULTIPLE_SALES:
+        return <CreateMultipleSalesModal />;
+      case MODAL_TYPES.CANCEL_SALE:
+        return <CancelSaleModal />;
+      case MODAL_TYPES.CANCEL_ALL_SALES:
+        return <CancelAllSalesModal />;
       default:
         return null;
     }

--- a/components/Provider/ModalProvider.tsx
+++ b/components/Provider/ModalProvider.tsx
@@ -1,26 +1,66 @@
-import { useState, createContext, useContext, ReactNode } from 'react';
+import {
+  useState,
+  createContext,
+  useContext,
+  ReactNode,
+  Dispatch,
+  SetStateAction,
+} from 'react';
 import { useScrollLock } from '../../hooks';
 
 export const MODAL_TYPES = {
   HIDDEN: 'HIDDEN',
-  WITHDRAW: 'WITHDRAW',
   CLAIM: 'CLAIM',
+  CREATE_SALE: 'CREATE_SALE',
+  CREATE_MULTIPLE_SALES: 'CREATE_MULTIPLE_SALES',
+  CANCEL_SALE: 'CANCEL_SALE',
+  CANCEL_ALL_SALES: 'CANCEL_ALL_SALES',
 };
 
 type Props = {
   children: ReactNode;
 };
 
+interface SaleModalProps {
+  setShouldReload: Dispatch<SetStateAction<boolean>>;
+}
+
+export interface CancelSaleModalProps extends SaleModalProps {
+  saleId: string;
+}
+
+export interface CancelAllSalesModalProps extends SaleModalProps {
+  saleIds: string[];
+}
+
+export interface CreateSaleModalProps extends SaleModalProps {
+  assetId: string;
+}
+
+export interface CreateMultipleSalesModalProps extends SaleModalProps {
+  assetIds: string[];
+}
+
+type ModalProps =
+  | CancelSaleModalProps
+  | CancelAllSalesModalProps
+  | CreateSaleModalProps
+  | CreateMultipleSalesModalProps;
+
 type ModalContextValue = {
   modalType: string;
   openModal: (type: string) => void;
   closeModal: () => void;
+  modalProps: ModalProps;
+  setModalProps: Dispatch<SetStateAction<ModalProps>>;
 };
 
 const ModalContext = createContext<ModalContextValue>({
   modalType: MODAL_TYPES.HIDDEN,
   openModal: undefined,
   closeModal: undefined,
+  modalProps: undefined,
+  setModalProps: () => {},
 });
 
 export const useModalContext = (): ModalContextValue => {
@@ -30,6 +70,7 @@ export const useModalContext = (): ModalContextValue => {
 
 export const ModalProvider = ({ children }: Props): JSX.Element => {
   const [modalType, setModalType] = useState<string>(MODAL_TYPES.HIDDEN);
+  const [modalProps, setModalProps] = useState<ModalProps>(undefined);
   const openModal = (type: string) => setModalType(type);
   const closeModal = () => setModalType(MODAL_TYPES.HIDDEN);
   useScrollLock(modalType !== MODAL_TYPES.HIDDEN);
@@ -38,6 +79,8 @@ export const ModalProvider = ({ children }: Props): JSX.Element => {
     modalType,
     openModal,
     closeModal,
+    modalProps,
+    setModalProps,
   };
 
   return (

--- a/components/Provider/ModalProvider.tsx
+++ b/components/Provider/ModalProvider.tsx
@@ -14,7 +14,7 @@ export const MODAL_TYPES = {
   CREATE_SALE: 'CREATE_SALE',
   CREATE_MULTIPLE_SALES: 'CREATE_MULTIPLE_SALES',
   CANCEL_SALE: 'CANCEL_SALE',
-  CANCEL_ALL_SALES: 'CANCEL_ALL_SALES',
+  CANCEL_MULTIPLE_SALES: 'CANCEL_MULTIPLE_SALES',
 };
 
 type Props = {
@@ -29,7 +29,7 @@ export interface CancelSaleModalProps extends SaleModalProps {
   saleId: string;
 }
 
-export interface CancelAllSalesModalProps extends SaleModalProps {
+export interface CancelMultipleSalesModalProps extends SaleModalProps {
   saleIds: string[];
 }
 
@@ -43,7 +43,7 @@ export interface CreateMultipleSalesModalProps extends SaleModalProps {
 
 type ModalProps =
   | CancelSaleModalProps
-  | CancelAllSalesModalProps
+  | CancelMultipleSalesModalProps
   | CreateSaleModalProps
   | CreateMultipleSalesModalProps;
 

--- a/components/Provider/index.ts
+++ b/components/Provider/index.ts
@@ -1,2 +1,8 @@
 export { useAuthContext, AuthProvider } from './AuthProvider';
 export { useModalContext, ModalProvider, MODAL_TYPES } from './ModalProvider';
+export type {
+  CancelSaleModalProps,
+  CancelAllSalesModalProps,
+  CreateSaleModalProps,
+  CreateMultipleSalesModalProps,
+} from './ModalProvider';

--- a/components/Provider/index.ts
+++ b/components/Provider/index.ts
@@ -2,7 +2,7 @@ export { useAuthContext, AuthProvider } from './AuthProvider';
 export { useModalContext, ModalProvider, MODAL_TYPES } from './ModalProvider';
 export type {
   CancelSaleModalProps,
-  CancelAllSalesModalProps,
+  CancelMultipleSalesModalProps,
   CreateSaleModalProps,
   CreateMultipleSalesModalProps,
 } from './ModalProvider';

--- a/services/proton.ts
+++ b/services/proton.ts
@@ -48,8 +48,8 @@ interface DepositWithdrawResponse {
   error?: string;
 }
 
-export interface SaleResponse {
-  success?: boolean;
+interface SaleResponse {
+  success: boolean;
   transactionId?: string;
   error?: string;
 }

--- a/services/proton.ts
+++ b/services/proton.ts
@@ -38,8 +38,8 @@ interface DepositWithdrawResponse {
   error?: string;
 }
 
-interface SaleResponse {
-  success: boolean;
+export interface SaleResponse {
+  success?: boolean;
   transactionId?: string;
   error?: string;
 }


### PR DESCRIPTION
Testing steps:
1. Navigate to "My NFTs" and select an NFT you have not listed for sale
2. Click "Mark for sale" to open the `CreateSaleModal` - functionality from old button has been ported over into this modal
3. Click "Mark all for sale" to open the `CreateMultipleSalesModal` - functionality will be set up in WEB-834
4. Navigate to "My NFTs" and select an NFT you have listed for sale
5. Click "Cancel Sale" to open the `CancelSaleModal` - functionality from old button has been ported over into this modal
6. Click "Mark all for sale" to open the `CancelAllSalesModal` - functionality will be set up in WEB-834