### PR TITLE
WEB-854: Remove unnecessary sale fetch calls and clean up getUserTemplateAssets response

### DIFF
--- a/components/AssetFormSell/index.tsx
+++ b/components/AssetFormSell/index.tsx
@@ -35,7 +35,6 @@ export const AssetFormSell = ({
     const dropdownAsset = dropdownAssets.find((asset) => {
       return asset.asset_id === id;
     });
-    console.log('handledropdown: ', dropdownAsset);
     setCurrentAsset(dropdownAsset);
   };
 

--- a/components/DetailsLayout/index.tsx
+++ b/components/DetailsLayout/index.tsx
@@ -35,7 +35,7 @@ const AssetImage = ({ image }: { image: string }): JSX.Element => (
       layout="responsive"
       width={456}
       height={470}
-      src={`https://ipfs.io/ipfs/${image}`}
+      src={`https://cloudflare-ipfs.com/ipfs/${image}`}
     />
   </ImageContainer>
 );

--- a/components/GridCard/index.tsx
+++ b/components/GridCard/index.tsx
@@ -66,7 +66,7 @@ const Card = ({
           width={213}
           height={220}
           alt={text}
-          src={`https://ipfs.io/ipfs/${image}`}
+          src={`https://cloudflare-ipfs.com/ipfs/${image}`}
         />
         {isUsersTemplates ? (
           <Tag>

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   images: {
-    domains: ['ipfs.io'],
+    domains: ['cloudflare-ipfs.com'],
   },
   webpack(config) {
     config.module.rules.push({


### PR DESCRIPTION
This PR takes care of:
- Reducing the amount of `/sales` fetch calls to prevent the possibility of the `Rate limit` error
- Cleaning up the `getUserTemplateAssets` response

### Fetch Count Before

<img width="1680" alt="Screen Shot 2021-03-26 at 3 52 36 PM" src="https://user-images.githubusercontent.com/32081352/112701630-664f5300-8e4e-11eb-86dc-a0a07b9f760b.png">

### Fetch Count After

<img width="1680" alt="Screen Shot 2021-03-26 at 3 55 05 PM" src="https://user-images.githubusercontent.com/32081352/112701632-68191680-8e4e-11eb-8662-94ce0fc610a0.png">
