### PR TITLE
WEB-890: Add collection whitelist parameter for My NFTs template fetch

### DIFF
--- a/services/templates.ts
+++ b/services/templates.ts
@@ -270,7 +270,7 @@ export const getTemplatesWithUserAssetCount = async (
 ): Promise<Template[]> => {
   try {
     const accountResponse = await getFromApi<Account>(
-      `${process.env.NEXT_PUBLIC_NFT_ENDPOINT}/atomicassets/v1/accounts/${owner}`
+      `${process.env.NEXT_PUBLIC_NFT_ENDPOINT}/atomicassets/v1/accounts/${owner}?collection_whitelist=${DEFAULT_COLLECTION}`
     );
 
     if (!accountResponse.success) {
@@ -278,7 +278,7 @@ export const getTemplatesWithUserAssetCount = async (
     }
 
     const accountResponseWithHidden = await getFromApi<Account>(
-      `${process.env.NEXT_PUBLIC_NFT_ENDPOINT}/atomicassets/v1/accounts/${owner}?hide_offers=true`
+      `${process.env.NEXT_PUBLIC_NFT_ENDPOINT}/atomicassets/v1/accounts/${owner}?hide_offers=true&collection_whitelist=${DEFAULT_COLLECTION}`
     );
 
     if (!accountResponseWithHidden.success) {


### PR DESCRIPTION
This PR resolves issue #90 by adding a query parameter to only whitelist the application's `DEFAULT_COLLECTION` (monsters).